### PR TITLE
allow path to be specified as an array

### DIFF
--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -23,6 +23,15 @@ describe 'logrotate::rule' do
       }).with_content("/var/log/foo.log {\n}\n")
     end
 
+    context 'with an array path' do
+      let (:params) { {:path => ['/var/log/foo1.log','/var/log/foo2.log']} }
+        it do
+          should contain_file('/etc/logrotate.d/test').with_content(
+            "/var/log/foo1.log /var/log/foo2.log {\n}\n"
+          )
+        end
+    end
+
     ###########################################################################
     # COMPRESS
     context 'and compress => true' do

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -1,6 +1,12 @@
 <%
   opts = []
 
+  if path.kind_of?(Array)
+    rpath = path.join(' ')
+  else
+    rpath = path
+  end
+
   if has_variable?('_create')
     if _create == 'create'
       opts << [_create, create_mode, create_owner, create_group].reject { |r|
@@ -28,7 +34,7 @@
     opts << "#{key} #{value}" if value != 'undef'
   end
 -%>
-<%= path %> {
+<%= rpath %> {
 <% opts.each do |opt| -%>
   <%= opt %>
 <% end -%>


### PR DESCRIPTION
If the path is specified as an array the template would just concatenate everything together.  This change inserts the spaces between the strings that make logrotate happy.
