### PR TITLE
We were getting the following deprecation warning written to syslog afte...

### DIFF
--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -22,7 +22,8 @@
     '_mail', '_missingok', '_olddir', '_sharedscripts', '_ifempty', '_maillast',
     '_mailfirst', '_shred', '_rotate_every'
   ].each do |bool|
-    opts << eval(bool) if has_variable?(bool)
+    global_bool = '::'+bool
+    opts << eval(global_bool) if has_variable?(global_bool)
   end
 
   [


### PR DESCRIPTION
...r we started using puppet-logrotate:

Dynamic lookup of $_sharedscripts at /etc/puppet/modules/logrotate/templates/etc/logrotate.d/rule.erb:29 is deprecated.  Support will be removed in Puppet 2.8.  Use a fully-qualified variable name (e.g., $classname::variable) or parameterized classes.

These changes add a '::' prefix to the global variables defined in logrotate::rule() so puppet no longer generates the deprecation notices.
