### PR TITLE
allow dots in the rule resource title - This allows creating 'site.com' ...

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -148,7 +148,7 @@ define logrotate::rule(
   #############################################################################
   # SANITY CHECK VALUES
 
-  if $name !~ /^[a-zA-Z0-9_-]+$/ {
+  if $name !~ /^[a-zA-Z0-9\._-]+$/ {
     fail("Logrotate::Rule[${name}]: namevar must be alphanumeric")
   }
 


### PR DESCRIPTION
allow dots in the logrotate::rule resource title - This allows creating 'site.com' style rules for each vhost

```
logrotate::rule { 'site.com:
  ..
  ...
}
```
