### PR TITLE
add defaults for redhat/centos

### DIFF
--- a/manifests/defaults/redhat.pp
+++ b/manifests/defaults/redhat.pp
@@ -1,0 +1,25 @@
+# Internal: Manage the default redhat logrotate rules.
+#
+# Examples
+#
+#   include logrotate::defaults::redhat
+class logrotate::defaults::redhat {
+  Logrotate::Rule {
+    rotate_every => 'month',
+    create       => true,
+    create_owner => 'root',
+    create_group => 'utmp',
+    rotate       => 1,
+  }
+
+  logrotate::rule {
+    'wtmp':
+      path        => '/var/log/wtmp',
+      create_mode => '0664',
+      minsize     => '1M';
+    'btmp':
+      path        => '/var/log/btmp',
+      create_mode => '0660',
+      missingok   => true;
+  }
+}


### PR DESCRIPTION
RHEL5.x has a default logrotate entry for wmtp

/var/log/wtmp {
    monthly
    minsize 1M
    create 0664 root utmp
    rotate 1
}

RHEL6.x has default logrotate entries for wtmp and btmp
/var/log/wtmp {
    monthly
    create 0664 root utmp
    minsize 1M
    rotate 1
}

/var/log/btmp {
    missingok
    monthly
    create 0600 root utmp
    rotate 1
}
