### PR TITLE
add default logrotate entries for redhat/centos

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -32,6 +32,9 @@ class logrotate::base {
     'Debian','Ubuntu': {
       include logrotate::defaults::debian
     }
+    'RedHat','CentOS': {
+      include logrotate::defaults::redhat
+    }
     default: { }
   }
 }

--- a/manifests/defaults/redhat.pp
+++ b/manifests/defaults/redhat.pp
@@ -1,0 +1,25 @@
+# Internal: Manage the default redhat logrotate rules.
+#
+# Examples
+#
+#   include logrotate::defaults::redhat
+class logrotate::defaults::redhat {
+  Logrotate::Rule {
+    rotate_every => 'month',
+    create       => true,
+    create_owner => 'root',
+    create_group => 'utmp',
+    rotate       => 1,
+  }
+
+  logrotate::rule {
+    'wtmp':
+      path        => '/var/log/wtmp',
+      create_mode => '0664',
+      minsize     => '1M';
+    'btmp':
+      path        => '/var/log/btmp',
+      create_mode => '0660',
+      missingok   => true;
+  }
+}


### PR DESCRIPTION
RHEL 5.x has a default logrotate config for wtmp:
/var/log/wtmp {
    monthly
    minsize 1M
    create 0664 root utmp
    rotate 1
}

RHEL 6.x has default logrotate configs for wtmp and btmp:
/var/log/wtmp {
    monthly
    create 0664 root utmp
    minsize 1M
    rotate 1
}
/var/log/btmp {
    missingok
    monthly
    create 0600 root utmp
    rotate 1
}
