### PR TITLE
Updates for Centos and Amazom Linux

### DIFF
--- a/files/etc/cron.daily/logrotate
+++ b/files/etc/cron.daily/logrotate
@@ -2,5 +2,10 @@
 # THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET.  ANY CHANGES WILL BE
 # OVERWRITTEN.
 
-test -x /usr/sbin/logrotate || exit 0
-/usr/sbin/logrotate /etc/logrotate.conf
+/usr/sbin/logrotate /etc/logrotate.conf >/dev/null 2>&1
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+fi
+exit 0
+

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -29,8 +29,8 @@ class logrotate::base {
   }
 
   case $::operatingsystem {
-    'Debian','Ubuntu': {
-      include logrotate::defaults::debian
+    'Debian','Ubuntu','centos','Amazom': {
+      include logrotate::defaults::utmpbtmp
     }
     default: { }
   }

--- a/manifests/defaults/utmpbtmp.pp
+++ b/manifests/defaults/utmpbtmp.pp
@@ -3,7 +3,7 @@
 # Examples
 #
 #   include logrotate::defaults::debian
-class logrotate::defaults::debian {
+class logrotate::defaults::utmpbtmp {
   Logrotate::Rule {
     missingok    => true,
     rotate_every => 'month',


### PR DESCRIPTION
Updated the cron job to the current Centos (Amazon) 6 syntax.  This might be the same for RHEL, but did not test. Might better for a template and install as per os or os family.

Also  "defauts::debian" are also needed for these OSes,  renamed to a generic name and updated the base class.
