### PR TITLE
Fix Anacron issue w/ hanging on logrotate

### DIFF
--- a/files/etc/cron.daily/logrotate
+++ b/files/etc/cron.daily/logrotate
@@ -2,5 +2,9 @@
 # THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET.  ANY CHANGES WILL BE
 # OVERWRITTEN.
 
-test -x /usr/sbin/logrotate || exit 0
-/usr/sbin/logrotate /etc/logrotate.conf
+/usr/sbin/logrotate /etc/logrotate.conf > /dev/null 2>&1 
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+fi
+exit 0


### PR DESCRIPTION
Per RH Bug:https://bugzilla.redhat.com/show_bug.cgi?id=517321

Fixes the wait for output in the run parts command on RHEL / Centos.

This is actually the current version of this file pushed out with the logrotate package.
