### PR TITLE
Added support for `su` option introduced in logrotate 3.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ shredcycles     - The Integer number of times shred should overwrite log files
                   before unlinking them (optional).
 start           - The Integer number to be used as the base for the extensions
                   appended to the rotated log files (optional).
+su              - A Boolean specifying whether logrotate should rotate under a
+                  specific user and group instead of the default (optional).
+                  First available in logrotate 3.8.0.
+su_owner        - A username String that logrotate should use to rotate a
+                  log file set instead of using the default if
+                  su => true (optional).
+su_group        - A String group name that logrotate should use to rotate a
+                  log file set instead of using the default if
+                  su => true (optional).
 uncompresscmd   - The String command to be used to uncompress log files
                   (optional).
 ```

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -82,6 +82,15 @@
 #                   before unlinking them (optional).
 # start           - The Integer number to be used as the base for the extensions
 #                   appended to the rotated log files (optional).
+# su              - A Boolean specifying whether logrotate should rotate under a
+#                   specific user and group instead of the default (optional).
+#                   First available in logrotate 3.8.0.
+# su_owner        - A username String that logrotate should use to rotate a
+#                   log file set instead of using the default if
+#                   su => true (optional).
+# su_group        - A String group name that logrotate should use to rotate a
+#                   log file set instead of using the default if
+#                   su => true (optional).
 # uncompresscmd   - The String command to be used to uncompress log files
 #                   (optional).
 #
@@ -142,6 +151,9 @@ define logrotate::rule(
                         $shred           = 'undef',
                         $shredcycles     = 'undef',
                         $start           = 'undef',
+                        $su              = 'undef',
+                        $su_owner        = 'undef',
+                        $su_group        = 'undef',
                         $uncompresscmd   = 'undef'
                         ) {
 
@@ -331,6 +343,14 @@ define logrotate::rule(
     }
   }
 
+  case $su {
+    'undef',false: {}
+    true: { $_su = 'su' }
+    default: {
+      fail("Logrotate::Rule[${name}]: su must be a boolean")
+    }
+  }
+
   case $mailfirst {
     'undef',false: {}
     true: {
@@ -367,6 +387,14 @@ define logrotate::rule(
     fail("Logrotate::Rule[${name}]: create_mode requires create")
   }
 
+  # su validation
+  if ($su_group != 'undef') and ($su_owner == 'undef') {
+    fail("Logrotate::Rule[${name}]: su_group requires su_owner")
+  }
+
+  if ($su_owner != 'undef') and ($su != true) {
+    fail("Logrotate::Rule[${name}]: su_owner requires su")
+  }
   #############################################################################
   #
 

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -981,6 +981,100 @@ describe 'logrotate::rule' do
     end
 
     ###########################################################################
+    # SU / SU_OWNER / SU_GROUP
+    context 'and su => true' do
+      let(:params) {
+        {:path => '/var/log/foo.log', :su => true}
+      }
+
+      context 'and su_owner => www-data' do
+        let(:params) {
+          {
+            :path     => '/var/log/foo.log',
+            :su       => true,
+            :su_owner => 'www-data',
+          }
+        }
+
+        it do
+          should contain_file('/etc/logrotate.d/test') \
+            .with_content(/^  su www-data/)
+        end
+
+        context 'and su_group => admin' do
+          let(:params) {
+            {
+              :path     => '/var/log/foo.log',
+              :su       => true,
+              :su_owner => 'www-data',
+              :su_group => 'admin',
+            }
+          }
+
+          it do
+            should contain_file('/etc/logrotate.d/test') \
+              .with_content(/^  su www-data admin$/)
+          end
+        end
+      end
+
+      context 'and su_group => admin' do
+        let(:params) {
+          {
+            :path     => '/var/log/foo.log',
+            :su       => true,
+            :su_group => 'admin',
+          }
+        }
+
+        it do
+          expect {
+            should contain_file('/etc/logrotate.d/test')
+          }.to raise_error(Puppet::Error, /su_group requires su_owner/)
+        end
+      end
+    end
+
+    context 'and su => false' do
+      let(:params) {
+        {:path => '/var/log/foo.log', :su => false}
+      }
+
+      it do
+        should_not contain_file('/etc/logrotate.d/test') \
+          .with_content(/^  su\s/)
+      end
+
+      context 'and su_owner => wwww-data' do
+        let(:params) {
+          {
+            :path     => '/var/log/foo.log',
+            :su       => false,
+            :su_owner => 'www-data',
+          }
+        }
+
+        it do
+          expect {
+            should contain_file('/etc/logrotate.d/test')
+          }.to raise_error(Puppet::Error, /su_owner requires su/)
+        end
+      end
+    end
+
+    context 'and su => foo' do
+      let(:params) {
+        {:path => '/var/log/foo.log', :su => 'foo'}
+      }
+
+      it do
+        expect {
+          should contain_file('/etc/logrotate.d/test')
+        }.to raise_error(Puppet::Error, /su must be a boolean/)
+      end
+    end
+
+    ###########################################################################
     # UNCOMPRESSCMD
     context 'and uncompresscmd => bunzip2' do
       let(:params) {

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -17,6 +17,16 @@
     end
   end
 
+  if scope.to_hash.has_key?('_su')
+    if @_su == 'su'
+      opts << [@_su, @su_owner, @su_group].reject { |r|
+        r == 'undef'
+      }.join(' ')
+    else
+      opts << @_su
+    end
+  end
+
   [
     '_compress', '_copy', '_copytruncate', '_delaycompress', '_dateext',
     '_mail', '_missingok', '_olddir', '_sharedscripts', '_ifempty', '_maillast',


### PR DESCRIPTION
As requested by issue #14, added `su` support introduced in logrotate 3.8.0.  This introduces three new `logrotate::rule` parameters, `$su`, `$su_owner`, `$su_group` and are modeled after the existing `$create*` options for consistency.  Also added full testing and passed `script/cibuild`.

See: http://svn.fedorahosted.org/svn/logrotate/tags/r3-8-0/CHANGES
