### PR TITLE
Correcting su validation and tests when su => false

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ shredcycles     - The Integer number of times shred should overwrite log files
                   before unlinking them (optional).
 start           - The Integer number to be used as the base for the extensions
                   appended to the rotated log files (optional).
-su              - A Boolean specifying whether logrotate should rotate under a
-                  specific user and group instead of the default (optional).
-                  First available in logrotate 3.8.0.
+su              - A Boolean specifying whether logrotate should rotate under
+                  the specific su_owner and su_group instead of the default.
+                  First available in logrotate 3.8.0. (optional)
 su_owner        - A username String that logrotate should use to rotate a
                   log file set instead of using the default if
                   su => true (optional).

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -82,9 +82,9 @@
 #                   before unlinking them (optional).
 # start           - The Integer number to be used as the base for the extensions
 #                   appended to the rotated log files (optional).
-# su              - A Boolean specifying whether logrotate should rotate under a
-#                   specific user and group instead of the default (optional).
-#                   First available in logrotate 3.8.0.
+# su              - A Boolean specifying whether logrotate should rotate under
+#                   the specific su_owner and su_group instead of the default.
+#                   First available in logrotate 3.8.0. (optional)
 # su_owner        - A username String that logrotate should use to rotate a
 #                   log file set instead of using the default if
 #                   su => true (optional).
@@ -387,14 +387,16 @@ define logrotate::rule(
     fail("Logrotate::Rule[${name}]: create_mode requires create")
   }
 
-  # su validation
-  if ($su_group != 'undef') and ($su_owner == 'undef') {
-    fail("Logrotate::Rule[${name}]: su_group requires su_owner")
+  # su requires at least su_owner
+  if ($su == true) and ($su_owner == 'undef') {
+    fail("Logrotate::Rule[${name}]: su requires su_owner and optional su_group")
   }
 
+  # su should be set to true if su_owner exists
   if ($su_owner != 'undef') and ($su != true) {
     fail("Logrotate::Rule[${name}]: su_owner requires su")
   }
+
   #############################################################################
   #
 

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -1018,19 +1018,18 @@ describe 'logrotate::rule' do
         end
       end
 
-      context 'and su_group => admin' do
+      context 'and missing su_owner' do
         let(:params) {
           {
-            :path     => '/var/log/foo.log',
-            :su       => true,
-            :su_group => 'admin',
+            :path => '/var/log/foo.log',
+            :su   => true,
           }
         }
 
         it do
           expect {
             should contain_file('/etc/logrotate.d/test')
-          }.to raise_error(Puppet::Error, /su_group requires su_owner/)
+          }.to raise_error(Puppet::Error, /su requires su_owner/)
         end
       end
     end

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -25,8 +25,6 @@
       opts << [@_su, @su_owner, @su_group].reject { |r|
         r == 'undef'
       }.join(' ')
-    else
-      opts << @_su
     end
   end
 


### PR DESCRIPTION
I realized earlier that I had made one more change to the branch in PR #19, but forgot to push it out.  My original su changes in 4cdd03f and 2a89fde have a bug that allows su to be true, but no owner set. (The 'su' option has no 'nosu' version to go with it and would have created an invalid config.)  This PR fixes that bug.
#### Commit Message:

The su config option works differently than other logrotate config
options and does not have a corresponding 'nosu' version.  This adds
proper validation checks, tests and erb handling to allow for this.

Without this, it would be possible to have only 'su' in the logrotate
rule if no owner or group was specified.
