### PR TITLE
Removed OS specific settings, this is user data and should not be define...

### DIFF
--- a/manifests/defaults/debian.pp
+++ b/manifests/defaults/debian.pp
@@ -12,13 +12,4 @@ class logrotate::defaults::debian {
     create_group => 'utmp',
     rotate       => 1,
   }
-
-  logrotate::rule {
-    'wtmp':
-      path        => '/var/log/wtmp',
-      create_mode => '0664';
-    'btmp':
-      path        => '/var/log/btmp',
-      create_mode => '0660';
-  }
 }

--- a/manifests/defaults/redhat.pp
+++ b/manifests/defaults/redhat.pp
@@ -12,16 +12,4 @@ class logrotate::defaults::redhat {
     create_group => 'utmp',
     rotate       => 1,
   }
-
-  logrotate::rule {
-    'wtmp':
-      path        => '/var/log/wtmp',
-      create_mode => '0664',
-      missingok   => false,
-      minsize     => '1M';
-    'btmp':
-      path        => '/var/log/btmp',
-      create_mode => '0660',
-      minsize     => '1M';
-  }
 }

--- a/manifests/defaults/suse.pp
+++ b/manifests/defaults/suse.pp
@@ -14,15 +14,4 @@ class logrotate::defaults::suse {
     maxage       => 365,
     size         => '400k'
   }
-
-  logrotate::rule {
-    'wtmp':
-      path         => '/var/log/wtmp',
-      create_mode  => '0664',
-      missingok    => false;
-    'btmp':
-      path         => '/var/log/btmp',
-      create_mode  => '0600',
-      create_group => 'root';
-  }
 }


### PR DESCRIPTION
Hello,

today I stubbled upon a duplicate resource declaration error trying to rotate wtmp;
I was quite baffled because i had no duplicate declaration in my node definition whatsoever.

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Logrotate::Rule[wtmp] is already declared in file /etc/puppet/manifests/nodes/basenode.pp at line 63; cannot redeclare on node someserver.tld.be
```

After some time I found out logrotate::base includes some OS specific defaults.
Could it perhaps be more opportune not to define OS specific settings in the logrotate::base class?

I agree with the Logrotate::Rule global setting, but defining settings (wtmp) for a specific OS should be included in a module for global purpose.

Kind regards
Fabian
