### PR TITLE
Ensure old config is removed when chaning to/from hourly rotation

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -406,9 +406,17 @@ define logrotate::rule(
     'hour', 'hourly': {
       include logrotate::hourly
       $rule_path = "/etc/logrotate.d/hourly/${name}"
+
+      file { "/etc/logrotate.d/${name}":
+        ensure => absent,
+      }
     }
     default: {
       $rule_path = "/etc/logrotate.d/${name}"
+
+      file { "/etc/logrotate.d/hourly/${name}":
+        ensure => absent,
+      }
     }
   }
 

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -744,6 +744,7 @@ describe 'logrotate::rule' do
 
       it { should contain_class('logrotate::hourly') }
       it { should contain_file('/etc/logrotate.d/hourly/test') }
+      it { should contain_file('/etc/logrotate.d/test').with_ensure('absent') }
     end
 
     context 'and rotate_every => day' do
@@ -754,6 +755,11 @@ describe 'logrotate::rule' do
       it do
         should contain_file('/etc/logrotate.d/test') \
           .with_content(/^  daily$/)
+      end
+
+      it do
+        should contain_file('/etc/logrotate.d/hourly/test') \
+           .with_ensure('absent')
       end
     end
 
@@ -766,6 +772,11 @@ describe 'logrotate::rule' do
         should contain_file('/etc/logrotate.d/test') \
           .with_content(/^  weekly$/)
       end
+
+      it do
+        should contain_file('/etc/logrotate.d/hourly/test') \
+           .with_ensure('absent')
+      end
     end
 
     context 'and rotate_every => month' do
@@ -777,6 +788,11 @@ describe 'logrotate::rule' do
         should contain_file('/etc/logrotate.d/test') \
           .with_content(/^  monthly$/)
       end
+
+      it do
+        should contain_file('/etc/logrotate.d/hourly/test') \
+           .with_ensure('absent')
+      end
     end
 
     context 'and rotate_every => year' do
@@ -787,6 +803,11 @@ describe 'logrotate::rule' do
       it do
         should contain_file('/etc/logrotate.d/test') \
           .with_content(/^  yearly$/)
+      end
+
+      it do
+        should contain_file('/etc/logrotate.d/hourly/test') \
+           .with_ensure('absent')
       end
     end
 


### PR DESCRIPTION
When changing an existing rule to hourly, the config should be removed from
/etc/logrotate.d/. Similarly, when changing a rule from hourly, the config
should be removed from /etc/logrotate.d/hourly/.

Fixes #22
