### PR TITLE
Changed postrotate option to accept array value

### DIFF
--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -51,7 +51,9 @@
 <% end -%>
 <% if @postrotate != 'undef' -%>
   postrotate
-    <%= @postrotate %>
+<% @postrotate.each do |val| -%>
+    <%= val %>
+<% end -%>
   endscript
 <% end -%>
 <% if @prerotate != 'undef' -%>


### PR DESCRIPTION
This allows for multi-line postrotate values when a rotation requires
multiple commands to be executed upon completion.
