### PR TITLE
Improve cron script to hide command output unless it fails

### DIFF
--- a/files/etc/cron.daily/logrotate
+++ b/files/etc/cron.daily/logrotate
@@ -2,5 +2,10 @@
 # THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET.  ANY CHANGES WILL BE
 # OVERWRITTEN.
 
-test -x /usr/sbin/logrotate || exit 0
-/usr/sbin/logrotate /etc/logrotate.conf
+OUTPUT=$(/usr/sbin/logrotate /etc/logrotate.conf 2>&1)
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+    echo "${OUTPUT}"
+fi
+exit $EXITVALUE

--- a/files/etc/cron.hourly/logrotate
+++ b/files/etc/cron.hourly/logrotate
@@ -2,5 +2,10 @@
 # THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET.  ANY CHANGES WILL BE
 # OVERWRITTEN.
 
-test -x /usr/sbin/logrotate || exit 0
-/usr/sbin/logrotate /etc/logrotate.d/hourly
+OUTPUT=$(/usr/sbin/logrotate /etc/logrotate.d/hourly 2>&1)
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+    echo "${OUTPUT}"
+fi
+exit $EXITVALUE


### PR DESCRIPTION
Capture the output of logrotate and only print it if logrotate fails (this is the default behaviour on some distros but not other).

Fixes #24 #16
