### PR TITLE
Fix permissions for /var/log/btmp (sshd requires it to be 0600)

### DIFF
--- a/manifests/defaults/debian.pp
+++ b/manifests/defaults/debian.pp
@@ -19,6 +19,6 @@ class logrotate::defaults::debian {
       create_mode => '0664';
     'btmp':
       path        => '/var/log/btmp',
-      create_mode => '0660';
+      create_mode => '0600';
   }
 }

--- a/manifests/defaults/redhat.pp
+++ b/manifests/defaults/redhat.pp
@@ -21,7 +21,7 @@ class logrotate::defaults::redhat {
       minsize     => '1M';
     'btmp':
       path        => '/var/log/btmp',
-      create_mode => '0660',
+      create_mode => '0600',
       minsize     => '1M';
   }
 }

--- a/spec/classes/defaults_debian_spec.rb
+++ b/spec/classes/defaults_debian_spec.rb
@@ -16,7 +16,7 @@ describe 'logrotate::defaults::debian' do
       'rotate_every' => 'month',
       'rotate'       => '1',
       'create'       => true,
-      'create_mode'  => '0660',
+      'create_mode'  => '0600',
       'create_owner' => 'root',
       'create_group' => 'utmp',
       'missingok'    => true,


### PR DESCRIPTION
The `logrotate::defaults::suse` class correctly uses 0600 as the create_mode for /var/log/btmp, but `logrotate::defaults::redhat` and `logrotate::defaults::debian` use 0660. That causes sshd to emit the following error:

```
 sshd[24031]: Excess permission or bad ownership on file /var/log/btmp
```

Relevant Redhat bug: https://bugzilla.redhat.com/show_bug.cgi?id=485553
