### PR TITLE
add some tooling to logrotate::base to enhance flexibility

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  repositories:
+   'stdlib': "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+  symlinks:
+   'logrotate': "#{source_dir}"

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -3,9 +3,21 @@
 # Examples
 #
 #   include logrotate::base
-class logrotate::base {
-  package { 'logrotate':
-    ensure => latest,
+class logrotate::base(
+  $backup     = false,
+  $pkg_ensure = 'latest',
+  $pkg_name   = 'logrotate',
+  $purge      = false,
+){
+  validate_bool($purge)
+  validate_bool($backup)
+
+  validate_string($pkg_ensure)
+  validate_string($pkg_name)
+
+  package { $pkg_name:
+    ensure => $pkg_ensure,
+    alias  => 'logrotate',
   }
 
   File {
@@ -21,7 +33,9 @@ class logrotate::base {
       source  => 'puppet:///modules/logrotate/etc/logrotate.conf';
     '/etc/logrotate.d':
       ensure  => directory,
-      mode    => '0755';
+      backup  => $backup,
+      mode    => '0755',
+      purge   => $purge;
     '/etc/cron.daily/logrotate':
       ensure  => file,
       mode    => '0555',

--- a/spec/classes/base_spec.rb
+++ b/spec/classes/base_spec.rb
@@ -1,9 +1,50 @@
 require 'spec_helper'
 
 describe 'logrotate::base' do
+  context 'input validation' do
+    ['purge','backup'].each do |bools|
+      context "when #{bools} is not a boolean" do
+        let (:params){{bools => "BOGON"}}
+        it 'should fail' do
+          expect { subject }.to raise_error(Puppet::Error, /"BOGON" is not a boolean.  It looks to be a String/)
+        end
+      end
+    end#bools
+    ['pkg_ensure','pkg_name'].each do |strings|
+      context "when the #{strings} parameter is not a string" do
+        let (:params) {{strings => false }}
+        it 'should fail' do
+          expect { subject }.to raise_error(Puppet::Error, /false is not a string./)
+        end
+      end
+    end#strings
+  end
+  ['logrotate','mylogrotate'].each do |pkg_names|
+    context "when pkg_name has the value of #{pkg_names}" do
+      ['latest','present','somever==1.0*'].each do |pkg_ensure_vals|
+        context "when pkg_ensure has the value of #{pkg_ensure_vals}" do
+          let (:params) {{'pkg_ensure' => pkg_ensure_vals,'pkg_name' => pkg_names}}
+          it {should contain_package(pkg_names).with_ensure(pkg_ensure_vals).with_alias('logrotate')}
+        end
+      end
+    end
+  end
+  ['purge','backup'].each do |booltest|
+    [true,false].each do |boolval|
+      context "when #{booltest} is #{boolval}" do
+        let (:params){{booltest => boolval }}
+        it {should contain_file('/etc/logrotate.d').with({
+          'ensure'  => 'directory',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          booltest  => boolval,
+          'require' => 'Package[logrotate]',
+        })}
+      end
+    end
+  end
   it do
-    should contain_package('logrotate').with_ensure('latest')
-
     should contain_file('/etc/logrotate.conf').with({
       'ensure'  => 'file',
       'owner'   => 'root',
@@ -13,13 +54,6 @@ describe 'logrotate::base' do
       'require' => 'Package[logrotate]',
     })
 
-    should contain_file('/etc/logrotate.d').with({
-      'ensure'  => 'directory',
-      'owner'   => 'root',
-      'group'   => 'root',
-      'mode'    => '0755',
-      'require' => 'Package[logrotate]',
-    })
 
     should contain_file('/etc/cron.daily/logrotate').with({
       'ensure'  => 'file',
@@ -30,25 +64,20 @@ describe 'logrotate::base' do
       'require' => 'Package[logrotate]',
     })
   end
-
-  context 'on Debian' do
-    let(:facts) { {:osfamily => 'Debian'} }
-
-    it { should contain_class('logrotate::defaults::debian') }
+  ['Debian','RedHat','SuSE'].each do |osfam|
+    context "on #{osfam}" do
+      let(:facts) {{ :osfamily => osfam}}
+      it { should contain_class("logrotate::defaults::#{osfam.downcase}")}
+      ['purge','backup'].each do |bools|
+        context "when #{bools} is not a boolean" do
+          let (:params){{bools => "BOGON"}}
+          it 'should fail' do
+            expect { subject }.to raise_error(Puppet::Error, /"BOGON" is not a boolean.  It looks to be a String/)
+          end
+        end
+      end
+    end
   end
-
-  context 'on RedHat' do
-    let(:facts) { {:osfamily => 'RedHat'} }
-
-    it { should contain_class('logrotate::defaults::redhat') }
-  end
-
-  context 'on SuSE' do
-    let(:facts) { {:osfamily => 'SuSE'} }
-
-    it { should contain_class('logrotate::defaults::suse') }
-  end
-
   context 'on Gentoo' do
     let(:facts) { {:operatingsystem => 'Gentoo'} }
 


### PR DESCRIPTION
added the ability to specify the purge and backup behaviors of /etc/logrotate.d, and parameterized 
the packagename and ensure value of the logrotate package. Tests updated as well
