### PR TITLE
Adding dateyesterday option for logrotate rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ dateext         - A Boolean specifying whether rotated log files should be
                   (optional).
 dateformat      - The format String to be used for `dateext` (optional).
                   Valid specifiers are '%Y', '%m', '%d' and '%s'.
+dateyesterday   - A Boolean specifying whether to use yesterday's date instead
+                  of today's date to create the `dateext` extension (optional).
 delaycompress   - A Boolean specifying whether compression of the rotated
                   log file should be delayed until the next logrotate run
                   (optional).

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -29,6 +29,8 @@
 #                   (optional).
 # dateformat      - The format String to be used for `dateext` (optional).
 #                   Valid specifiers are '%Y', '%m', '%d' and '%s'.
+# dateyesterday   - A Boolean specifying whether to use yesterday's date instead
+#                   of today's date to create the `dateext` extension (optional).
 # delaycompress   - A Boolean specifying whether compression of the rotated
 #                   log file should be delayed until the next logrotate run
 #                   (optional).
@@ -131,6 +133,7 @@ define logrotate::rule(
                         $create_group    = 'undef',
                         $dateext         = 'undef',
                         $dateformat      = 'undef',
+                        $dateyesterday   = 'undef',
                         $delaycompress   = 'undef',
                         $extension       = 'undef',
                         $ifempty         = 'undef',
@@ -228,6 +231,15 @@ define logrotate::rule(
     false: { $sane_dateext = 'nodateext' }
     default: {
       fail("Logrotate::Rule[${name}]: dateext must be a boolean")
+    }
+  }
+
+  case $dateyesterday {
+    'undef': {}
+    true: { $sane_dateyesterday = 'dateyesterday' }
+    false: {}
+    default: {
+      fail("Logrotate::Rule[${name}]: dateyesterday must be a boolean")
     }
   }
 

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -30,7 +30,8 @@
 # dateformat      - The format String to be used for `dateext` (optional).
 #                   Valid specifiers are '%Y', '%m', '%d' and '%s'.
 # dateyesterday   - A Boolean specifying whether to use yesterday's date instead
-#                   of today's date to create the `dateext` extension (optional).
+#                   of today's date to create the `dateext` extension
+#                   (optional).
 # delaycompress   - A Boolean specifying whether compression of the rotated
 #                   log file should be delayed until the next logrotate run
 #                   (optional).

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -360,6 +360,42 @@ describe 'logrotate::rule' do
     end
 
     ###########################################################################
+    # DATEYESTERDAY
+    context 'and dateyesterday => true' do
+      let(:params) {
+        {:path => '/var/log/foo.log', :dateyesterday => true}
+      }
+
+      it do
+        should contain_file('/etc/logrotate.d/test') \
+          .with_content(/^  dateyesterday$/)
+      end
+    end
+
+    context 'and dateyesterday => false' do
+      let(:params) {
+        {:path => '/var/log/foo.log', :dateyesterday => false}
+      }
+
+      it do
+        should contain_file('/etc/logrotate.d/test') \
+          .without_content(/^  dateyesterday$/)
+      end
+    end
+
+    context 'and dateyesterday => foo' do
+      let(:params) {
+        {:path => '/var/log/foo.log', :dateyesterday => 'foo'}
+      }
+
+      it do
+        expect {
+          should contain_file('/etc/logrotate.d/test')
+        }.to raise_error(Puppet::Error, /dateyesterday must be a boolean/)
+      end
+    end
+
+    ###########################################################################
     # DELAYCOMPRESS
     context 'and delaycompress => true' do
       let(:params) {

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -31,7 +31,7 @@
   [
     'compress', 'copy', 'copytruncate', 'delaycompress', 'dateext',
     'mail', 'missingok', 'olddir', 'sharedscripts', 'ifempty', 'maillast',
-    'mailfirst', 'shred', 'rotate_every'
+    'mailfirst', 'shred', 'rotate_every', 'dateyesterday'
   ].each do |bool|
     opts << scope.to_hash["sane_#{bool}"] if scope.to_hash.has_key?("sane_#{bool}")
   end


### PR DESCRIPTION
Logrotate provides the functionality to use yesterday's date when labeling logs with dateext when specifying rotation rules. This pull request adds the ability to specify this flag when defining logrotate rules in a puppet manifest.

```
       dateyesterday
              Use yesterday's instead of today's date to create the dateext extension, so that the rotated log file has a date in its name that is  the  same  as  the
              timestamps within it.
```
