### PR TITLE
Replace deprecated Modulefile with metadata.json

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,7 +1,0 @@
-name 'rodjek-logrotate'
-version '1.1.1'
-source 'https://github.com/rodjek/puppet-logrotate'
-license 'MIT'
-summary 'Logrotate module'
-description 'Manage logrotate on your servers with Puppet'
-project_page 'https://github.com/rodjek/puppet-logrotate'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "rodjek-logrotate",
+  "version": "1.1.1",
+  "source": "https://github.com/rodjek/puppet-logrotate",
+  "author": "rodjek",
+  "license": "MIT",
+  "summary": "Logrotate module",
+  "description": "Manage logrotate on your servers with Puppet",
+  "project_page": "https://github.com/rodjek/puppet-logrotate",
+  "dependencies": []
+}


### PR DESCRIPTION
https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#publishing-modules-on-the-puppet-forge shows that Modulefiles are deprecated as of Puppet 3.5 and gone in Puppet 4.

To make this compatible with Puppet 4, I have removed the Modulefile and generated the appropriate metadata.json file.
