### PR TITLE
Add parameter to change the ensure status of the logwatch package

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -3,9 +3,11 @@
 # Examples
 #
 #   include logrotate::base
-class logrotate::base {
+class logrotate::base (
+  $package_ensure = 'latest',
+) {
   package { 'logrotate':
-    ensure => latest,
+    ensure => $package_ensure,
   }
 
   File {


### PR DESCRIPTION
Add parameter to change the ensure status of the logwatch package from `latest` to `present`. Default remains the same.

In my environment I don't want puppet to ensure the latest package exists on each run - I have a daily cron job for that.

The `$::package_ensure` variable should be set in hiera like `logwatch::base::package:ensure: present` or similar.
