### PR TITLE
 Removed the require => Class['logrotate::base'] to avoid dependency …

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -427,6 +427,5 @@ define logrotate::rule(
     group   => 'root',
     mode    => '0444',
     content => template('logrotate/etc/logrotate.d/rule.erb'),
-    require => Class['logrotate::base'],
   }
 }


### PR DESCRIPTION
Hello, 

   In order to be able to override parameters on Foreman, we need to remove that require to avoid dependency issues.

   It does not break its functionality on Puppet Enterprise and works now on Foreman.

---

 Info: Applying configuration version '1438371158'
 Error: Could not apply complete catalog: Found 1 dependency cycle:
 (File[/etc/logrotate.d/messages] => Logrotate::Rule[messages] => Class[Logrotate] => File[/etc/logrotate.d/messages])
 Try the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz
 Notice: Finished catalog run in 0.08 seconds

---
