### PR TITLE
Support alternative logger path

### DIFF
--- a/files/etc/cron.daily/logrotate.sles
+++ b/files/etc/cron.daily/logrotate.sles
@@ -1,0 +1,11 @@
+#!/bin/sh
+# THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET.  ANY CHANGES WILL BE
+# OVERWRITTEN.
+
+OUTPUT=$(/usr/sbin/logrotate /etc/logrotate.conf 2>&1)
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+    echo "${OUTPUT}"
+fi
+exit $EXITVALUE

--- a/files/etc/cron.hourly/logrotate.sles
+++ b/files/etc/cron.hourly/logrotate.sles
@@ -1,0 +1,11 @@
+#!/bin/sh
+# THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET.  ANY CHANGES WILL BE
+# OVERWRITTEN.
+
+OUTPUT=$(/usr/sbin/logrotate /etc/logrotate.d/hourly 2>&1)
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+    echo "${OUTPUT}"
+fi
+exit $EXITVALUE

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -25,19 +25,25 @@ class logrotate::base {
     '/etc/cron.daily/logrotate':
       ensure  => file,
       mode    => '0555',
-      source  => 'puppet:///modules/logrotate/etc/cron.daily/logrotate';
+      source  => "puppet:///modules/logrotate/etc/cron.daily/${logrotate_file}";
   }
 
   case $::osfamily {
     'Debian': {
       include logrotate::defaults::debian
+      $logrotate_file = 'logrotate'
     }
     'RedHat': {
       include logrotate::defaults::redhat
+      $logrotate_file = 'logrotate'
     }
     'SuSE': {
       include logrotate::defaults::suse
+      $logrotate_file = 'logrotate.sles'
     }
-    default: { }
+    default: {
+      $logrotate_file = 'logrotate'
+    }
   }
+
 }

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -14,20 +14,6 @@ class logrotate::base {
     require => Package['logrotate'],
   }
 
-  file {
-    '/etc/logrotate.conf':
-      ensure  => file,
-      mode    => '0444',
-      source  => 'puppet:///modules/logrotate/etc/logrotate.conf';
-    '/etc/logrotate.d':
-      ensure  => directory,
-      mode    => '0755';
-    '/etc/cron.daily/logrotate':
-      ensure  => file,
-      mode    => '0555',
-      source  => "puppet:///modules/logrotate/etc/cron.daily/${logrotate_file}";
-  }
-
   case $::osfamily {
     'Debian': {
       include logrotate::defaults::debian
@@ -44,6 +30,20 @@ class logrotate::base {
     default: {
       $logrotate_file = 'logrotate'
     }
+  }
+
+  file {
+    '/etc/logrotate.conf':
+      ensure  => file,
+      mode    => '0444',
+      source  => 'puppet:///modules/logrotate/etc/logrotate.conf';
+    '/etc/logrotate.d':
+      ensure  => directory,
+      mode    => '0755';
+    '/etc/cron.daily/logrotate':
+      ensure  => file,
+      mode    => '0555',
+      source  => "puppet:///modules/logrotate/etc/cron.daily/${logrotate_file}";
   }
 
 }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -36,10 +36,20 @@ class logrotate::hourly($ensure='present') {
       owner   => 'root',
       group   => 'root',
       mode    => '0555',
-      source  => 'puppet:///modules/logrotate/etc/cron.hourly/logrotate',
+      source  => "puppet:///modules/logrotate/etc/cron.hourly/${logrotate_file}",
       require => [
         File['/etc/logrotate.d/hourly'],
         Package['logrotate'],
       ];
   }
+
+  case $::osfamily {
+    'SuSE': {
+      $logrotate_file = 'logrotate.sles'
+    }
+    default: {
+      $logrotate_file = 'logrotate'
+    }
+  }
+
 }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -25,6 +25,15 @@ class logrotate::hourly($ensure='present') {
     }
   }
 
+  case $::osfamily {
+    'SuSE': {
+      $logrotate_file = 'logrotate.sles'
+    }
+    default: {
+      $logrotate_file = 'logrotate'
+    }
+  }
+
   file {
     '/etc/logrotate.d/hourly':
       ensure => $dir_ensure,
@@ -41,15 +50,6 @@ class logrotate::hourly($ensure='present') {
         File['/etc/logrotate.d/hourly'],
         Package['logrotate'],
       ];
-  }
-
-  case $::osfamily {
-    'SuSE': {
-      $logrotate_file = 'logrotate.sles'
-    }
-    default: {
-      $logrotate_file = 'logrotate'
-    }
   }
 
 }


### PR DESCRIPTION
On Sles the path to logger is different than expected  /usr/bin/logger  vs  /bin/logger

Signed-off-by: Christophe Vanlancker christophe.vanlancker@inuits.eu
