### PR TITLE
Fixes integer validation in Puppet 4

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -296,7 +296,7 @@ define logrotate::rule(
     }
   }
 
-  case $maxage {
+  case "${maxage}" {
     'undef': {}
     /^\d+$/: {}
     default: {
@@ -312,7 +312,7 @@ define logrotate::rule(
     }
   }
 
-  case $rotate {
+  case "${rotate}" {
     'undef': {}
     /^\d+$/: {}
     default: {
@@ -328,7 +328,7 @@ define logrotate::rule(
     }
   }
 
-  case $shredcycles {
+  case "${shredcycles}" {
     'undef': {}
     /^\d+$/: {}
     default: {
@@ -336,7 +336,7 @@ define logrotate::rule(
     }
   }
 
-  case $start {
+  case "${start}" {
     'undef': {}
     /^\d+$/: {}
     default: {


### PR DESCRIPTION
Case regex validation only succeeds on strings, which is somewhat
troublesome when using them to validate integers. By forcing any
passed integers to be strings, we cause integers to match the regex as
desired.

This fixes #46 
