### PR TITLE
Fixing tests.

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+puppet-logrotate

--- a/spec/classes/defaults_debian_spec.rb
+++ b/spec/classes/defaults_debian_spec.rb
@@ -4,7 +4,7 @@ describe 'logrotate::defaults::debian' do
   it do
     should contain_logrotate__rule('wtmp').with({
       'rotate_every' => 'month',
-      'rotate'       => '1',
+      'rotate'       => 1,
       'create'       => true,
       'create_mode'  => '0664',
       'create_owner' => 'root',
@@ -14,7 +14,7 @@ describe 'logrotate::defaults::debian' do
 
     should contain_logrotate__rule('btmp').with({
       'rotate_every' => 'month',
-      'rotate'       => '1',
+      'rotate'       => 1,
       'create'       => true,
       'create_mode'  => '0600',
       'create_owner' => 'root',


### PR DESCRIPTION
When I tried to compile the module, I got the following error message due to a type mistmatch
at `spec/classes/defaults_debian_spec.rb`.

`error during compilation: Evaluation Error: Error while evaluating a Function Call, Logrotate::Rule[wtmp]: rotate must be an integer`
