### PR TITLE
Configure logrotate.conf as template 

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -14,11 +14,18 @@ class logrotate::base {
     require => Package['logrotate'],
   }
 
+  case $::osfamily {
+    'Debian': {
+      $su_config = 'su root syslog'
+    }
+    default: { }
+  }
+
   file {
     '/etc/logrotate.conf':
       ensure  => file,
       mode    => '0444',
-      source  => 'puppet:///modules/logrotate/etc/logrotate.conf';
+      content => template('logrotate/etc/logrotate.conf.erb');
     '/etc/logrotate.d':
       ensure  => directory,
       mode    => '0755';

--- a/templates/etc/logrotate.conf.erb
+++ b/templates/etc/logrotate.conf.erb
@@ -11,5 +11,10 @@ rotate 4
 # create new (empty) log files after rotating old ones
 create
 
+<% if defined? @su_config %>
+# su config currently only configured for Debian
+<%= @su_config %>
+<% end %>
+
 # packages drop log rotation information into this directory
 include /etc/logrotate.d


### PR DESCRIPTION
I made this change as I needed to add the su config globally for Ubuntu. In order to accomplish this, it seemed to me that logrotate.conf should be a template not just a static file to allow for OS specific customization.

Thanks for your consideration.

Clark
