### PR TITLE
Convert to metadata.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,16 @@ script: ./script/cibuild
 before_install:
   - gem update --system 2.1.11
   - ./script/bootstrap
-rvm: 1.8.7
+matrix:
+  fast_finish: true
+  include:
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 3.0"
+    - rvm: 2.1.5
+      env: PUPPET_GEM_VERSION="~> 3.0"
+    - rvm: 2.1.5
+      env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+    - rvm: 2.1.6
+      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 notifications:
-  email:
-    - tim@github.com
-env:
-  - PUPPET_VERSION=2.6.18
-  - PUPPET_VERSION=2.7.24
-  - PUPPET_VERSION=3.0.2
-  - PUPPET_VERSION=3.1.1
-  - PUPPET_VERSION=3.2.4
-  - PUPPET_VERSION=3.3.2
-  - PUPPET_VERSION=3.4.1
+  email: false

--- a/Modulefile
+++ b/Modulefile
@@ -1,7 +1,0 @@
-name 'rodjek-logrotate'
-version '1.1.1'
-source 'https://github.com/rodjek/puppet-logrotate'
-license 'MIT'
-summary 'Logrotate module'
-description 'Manage logrotate on your servers with Puppet'
-project_page 'https://github.com/rodjek/puppet-logrotate'

--- a/files/etc/logrotate.d/rsyslog
+++ b/files/etc/logrotate.d/rsyslog
@@ -8,7 +8,7 @@
 	compress
   create 640 syslog adm
 	postrotate
-		reload rsyslog >/dev/null 2>&1 || true
+		service rsyslog rotate >/dev/null 2>&1 || true
 	endscript
 }
 
@@ -33,6 +33,6 @@
 	delaycompress
 	sharedscripts
 	postrotate
-		reload rsyslog >/dev/null 2>&1 || true
+		service rsyslog rotate >/dev/null 2>&1 || true
 	endscript
 }

--- a/files/etc/logrotate.d/rsyslog
+++ b/files/etc/logrotate.d/rsyslog
@@ -8,7 +8,7 @@
 	compress
   create 640 syslog adm
 	postrotate
-		service rsyslog rotate >/dev/null 2>&1 || true
+		service rsyslog restart >/dev/null 2>&1 || true
 	endscript
 }
 
@@ -33,6 +33,6 @@
 	delaycompress
 	sharedscripts
 	postrotate
-		service rsyslog rotate >/dev/null 2>&1 || true
+		service rsyslog restart >/dev/null 2>&1 || true
 	endscript
 }

--- a/files/etc/logrotate.d/rsyslog
+++ b/files/etc/logrotate.d/rsyslog
@@ -1,0 +1,38 @@
+/var/log/syslog
+{
+	rotate 7
+	daily
+	missingok
+	notifempty
+	delaycompress
+	compress
+  create 640 syslog adm
+	postrotate
+		reload rsyslog >/dev/null 2>&1 || true
+	endscript
+}
+
+/var/log/mail.info
+/var/log/mail.warn
+/var/log/mail.err
+/var/log/mail.log
+/var/log/daemon.log
+/var/log/kern.log
+/var/log/auth.log
+/var/log/user.log
+/var/log/lpr.log
+/var/log/cron.log
+/var/log/debug
+/var/log/messages
+{
+	rotate 4
+	weekly
+	missingok
+	notifempty
+	compress
+	delaycompress
+	sharedscripts
+	postrotate
+		reload rsyslog >/dev/null 2>&1 || true
+	endscript
+}

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -4,9 +4,9 @@
 #
 #   include logrotate::base
 class logrotate::base {
-  package { 'logrotate':
-    ensure => latest,
-  }
+  # package { 'logrotate':
+  #   ensure => latest,
+  # }
 
   File {
     owner   => 'root',

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -4,9 +4,9 @@
 #
 #   include logrotate::base
 class logrotate::base {
-  # package { 'logrotate':
-  #   ensure => latest,
-  # }
+  package { 'logrotate':
+    ensure => installed,
+  }
 
   File {
     owner   => 'root',

--- a/manifests/defaults/debian.pp
+++ b/manifests/defaults/debian.pp
@@ -21,4 +21,10 @@ class logrotate::defaults::debian {
       path        => '/var/log/btmp',
       create_mode => '0600';
   }
+
+  file { '/etc/logrotate.d/rsyslog':
+    ensure => file,
+    mode   => '0644',
+    source => 'puppet:///modules/logrotate/etc/logrotate.d/rsyslog';
+  }
 }

--- a/manifests/defaults/debian.pp
+++ b/manifests/defaults/debian.pp
@@ -22,9 +22,24 @@ class logrotate::defaults::debian {
       create_mode => '0600';
   }
 
+  case $::lsbdistrelease {
+    '12.04': {
+      $rsyslog_command = 'service rsyslog reload'
+    }
+    '14.04': {
+      $rsyslog_command = 'service rsyslog restart'
+    }
+    '16.04': {
+      $rsyslog_command = 'systemctl restart rsyslog'
+    }
+    default: {
+      $rsyslog_command = 'service rsyslog restart'
+    }
+  }
+
   file { '/etc/logrotate.d/rsyslog':
-    ensure => file,
-    mode   => '0644',
-    source => 'puppet:///modules/logrotate/etc/logrotate.d/rsyslog',
+    ensure  => file,
+    mode    => '0644',
+    content => template('logrotate/etc/logrotate.d/rsyslog'),
   }
 }

--- a/manifests/defaults/debian.pp
+++ b/manifests/defaults/debian.pp
@@ -25,6 +25,6 @@ class logrotate::defaults::debian {
   file { '/etc/logrotate.d/rsyslog':
     ensure => file,
     mode   => '0644',
-    source => 'puppet:///modules/logrotate/etc/logrotate.d/rsyslog';
+    source => 'puppet:///modules/logrotate/etc/logrotate.d/rsyslog',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,53 @@
+{
+  "name": "skyscrapers-logrotate",
+  "version": "1.1.1",
+  "summary": "Manage logrotate",
+  "license": "MIT",
+  "source": "https://github.com/skyscrapers/puppet-logrotate",
+  "project_page": "https://github.com/skyscrapers/puppet-logrotate",
+  "issues_url": "https://github.com/skyscrapers/puppet-logrotate/issues",
+  "tags": [
+    "logrotate"
+  ],
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 1.0.0 <5.0.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.2.0 < 5.0.0"
+    },
+    {
+      "name": "pe",
+      "version_requirement": ">= 3.2.0 < 2015.4.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    }
+  ]
+}

--- a/spec/classes/base_spec.rb
+++ b/spec/classes/base_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'logrotate::base' do
   it do
-    should contain_package('logrotate').with_ensure('latest')
+    should contain_package('logrotate').with_ensure('installed')
 
     should contain_file('/etc/logrotate.conf').with({
       'ensure'  => 'file',

--- a/templates/etc/logrotate.d/rsyslog
+++ b/templates/etc/logrotate.d/rsyslog
@@ -8,7 +8,7 @@
 	compress
   create 640 syslog adm
 	postrotate
-		service rsyslog restart >/dev/null 2>&1 || true
+		<%= @rsyslog_command %> >/dev/null 2>&1 || true
 	endscript
 }
 
@@ -33,6 +33,6 @@
 	delaycompress
 	sharedscripts
 	postrotate
-		service rsyslog restart >/dev/null 2>&1 || true
+		<%= @rsyslog_command %> >/dev/null 2>&1 || true
 	endscript
 }

--- a/templates/etc/logrotate.d/rsyslog
+++ b/templates/etc/logrotate.d/rsyslog
@@ -7,6 +7,7 @@
 	delaycompress
 	compress
   create 640 syslog adm
+	su root syslog
 	postrotate
 		<%= @rsyslog_command %> >/dev/null 2>&1 || true
 	endscript
@@ -32,6 +33,7 @@
 	compress
 	delaycompress
 	sharedscripts
+	su root syslog
 	postrotate
 		<%= @rsyslog_command %> >/dev/null 2>&1 || true
 	endscript


### PR DESCRIPTION
Converting the old Puppet `Modulefile` to the newer `metadata.json` setup. This change is currently needed to work with the test setup being put in place for `puppet-customer`. The dependency manager `librarian-puppet` barfs on the `Modulefile` in this repo. Repo's having a `metadata.json` work correctly.